### PR TITLE
i18n module abstraction

### DIFF
--- a/modules/i18n/pom.xml
+++ b/modules/i18n/pom.xml
@@ -92,15 +92,15 @@
 
     <!-- Spring Security -->
 
-      <dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      </dependency>
+    </dependency>
 
-      <dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      </dependency>
+    </dependency>
 
 
     <!-- for Object Relational Mapping (JPA/Hibernate) -->
@@ -246,45 +246,45 @@
       <version>3.7.1</version>
     </dependency>
 
-    <dependency>
+    <!-- <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.6.1</version>
-
-    </dependency>
-
+      </dependency>
+    -->
+    
     <dependency>
-    <groupId>net.sf.m-m-m</groupId>
-    <artifactId>mmm-util-cli</artifactId>
-    <version>7.0.0</version>
+      <groupId>net.sf.m-m-m</groupId>
+      <artifactId>mmm-util-cli</artifactId>
+      <version>7.0.0</version>
     </dependency>
     <dependency>
       <groupId>net.sf.m-m-m</groupId>
       <artifactId>mmm-util-core</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
     </dependency>
     <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
     </dependency>
     <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-        <groupId>org.reflections</groupId>
-        <artifactId>reflections</artifactId>
-        <version>0.9.10</version>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.10</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.json/json -->
-<dependency>
-    <groupId>org.json</groupId>
-    <artifactId>json</artifactId>
-</dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+    </dependency>
 
   </dependencies>
 </project>

--- a/modules/i18n/src/main/java/com/capgemini/devonfw/module/i18n/logic/api/I18n.java
+++ b/modules/i18n/src/main/java/com/capgemini/devonfw/module/i18n/logic/api/I18n.java
@@ -20,4 +20,12 @@ public interface I18n {
 
   public String getResourcesAsJSONStringForLocale(String locale, String filter) throws Throwable;
 
+  /**
+   * @param locale
+   * @param filter
+   * @return
+   * @throws Throwable
+   */
+  String getResourceObject(String locale, String filter) throws Throwable;
+
 }

--- a/modules/i18n/src/main/java/com/capgemini/devonfw/module/i18n/logic/impl/I18nImpl.java
+++ b/modules/i18n/src/main/java/com/capgemini/devonfw/module/i18n/logic/impl/I18nImpl.java
@@ -28,7 +28,10 @@ public class I18nImpl implements I18n {
   private static final Logger LOGGER = LoggerFactory.getLogger(I18nImpl.class);
 
   @Value("${i18n.mmm.enabled}")
-  private boolean mmmEnabled;
+  private boolean mmmEnabled = true;
+
+  @Value("${i18n.input.name}")
+  private String inputName = "mmm";
 
   /*
    * @Value("${i18n.mmm.default}") private String mmmDefault;
@@ -42,7 +45,7 @@ public class I18nImpl implements I18n {
    * @throws Throwable thrown by getResourcesAsJSONStringForLocale
    *
    */
-
+  @Deprecated
   @Override
   public String getResourcesAsJSONStringForLocale(String locale, String filter) throws Throwable {
 
@@ -55,6 +58,31 @@ public class I18nImpl implements I18n {
       jsonString = getResourcesAsJSONStringUsingMMMImpl(locale, filter);
     } else
       jsonString = getResourcesAsJSONStringUsingDefaultImpl(locale, filter);
+    return jsonString;
+  }
+
+  /**
+   * This methods read input from config.properties file. We need to set value of i18n.input.name in config.properties
+   * file. Default value for it is "standard".
+   */
+  @Override
+  public String getResourceObject(String locale, String filter) throws Throwable {
+
+    String jsonString = null;
+
+    switch (this.inputName.toLowerCase()) {
+    case "mmm":
+      jsonString = getResourcesAsJSONStringUsingMMMImpl(locale, filter);
+      break;
+
+    case "standard":
+      jsonString = getResourcesAsJSONStringUsingDefaultImpl(locale, filter);
+      break;
+
+    case "ownmodule":
+      jsonString = "value: ownModule";
+      break;
+    }
     return jsonString;
   }
 

--- a/modules/i18n/src/main/java/com/capgemini/devonfw/module/i18n/service/impl/rest/I18nRestServiceImpl.java
+++ b/modules/i18n/src/main/java/com/capgemini/devonfw/module/i18n/service/impl/rest/I18nRestServiceImpl.java
@@ -48,6 +48,6 @@ public class I18nRestServiceImpl {
   public String getResourcesForLocale(@PathParam("locale") String locale, @QueryParam("filter") String filter)
       throws Throwable {
 
-    return this.i18n.getResourcesAsJSONStringForLocale(locale, filter);
+    return this.i18n.getResourceObject(locale, filter);
   }
 }

--- a/modules/i18n/src/main/resources/com/capgemini/devonfw/module/i18n/common/api/nls/NlsBundleI18n_en.properties
+++ b/modules/i18n/src/main/resources/com/capgemini/devonfw/module/i18n/common/api/nls/NlsBundleI18n_en.properties
@@ -1,3 +1,5 @@
 # Generated 2016-07-21 16:01:29 +0530
 getLocale = TODO(en):{name}. This Module is related to internationalization
 messageSayHi = TODO(en):Hello {name}
+# Updated 2017-03-01 14:51:59 +0530
+errorLoginInUse = TODO(en):Sorry. The login "{login}" is already in use. Please choose a different login.

--- a/modules/i18n/src/main/resources/config.properties
+++ b/modules/i18n/src/main/resources/config.properties
@@ -3,3 +3,4 @@
 
 i18n.mmm.enabled=false
 
+i18n.input.name=ownmodule


### PR DESCRIPTION
Hi ,

I have done changes in i18n module , now user can develop their customized module and can plug it with i18n module. This module should be able to return json data.

I have done below changes:
1. I have added 'i18n.input.name' property  in config.properties. It can have values as mmm, standard or customized module name. Default module selected is mmm.
2. I have added getResourceObject(String locale, String filter) method in I18nImpl class which return json string.
3. I have added @Deprecated annotation on getResourcesAsJSONStringForLocale(String locale, String filter) method.

To add and test customized module user needs to do follow below steps:
1.	Create new module which will be able to return json data from method call.
2.	Add dependency of this module in devonfw-i18n module. 
3.	In config.properties set
i18n.input.name =USER_MODULE_NAME
4.	In class com.capgemini.devonfw.module.i18n.logic.impl.I18nImpl modify getResourceObject() method add your switch case in it. 
5.	Clean and build your application and launch SpringBootApp.java. You can view i18n REST service in available REST webservices (http://localhost:8081/oasp4j-sample-server/services/rest/)
6.	To test i18n REST service, the general format of the service will be as follows:
<service root>/locale/<locale indicator>
eg. localhost:8081/oasp4j-sample-server/services/rest/i18n/locales/en_US

